### PR TITLE
Fix typo in word RuntimeError when opening nc-file

### DIFF
--- a/00_tef_core.ipynb
+++ b/00_tef_core.ipynb
@@ -65,7 +65,7 @@
     "        if isinstance(inputFile, str):\n",
     "            try:\n",
     "                self._read(inputFile, **kwargs)\n",
-    "            except (OSError, IOError, RunetimeError):\n",
+    "            except (OSError, IOError, RuntimeError):\n",
     "                raise IOError(\"Could not read file.\")\n",
     "        elif isinstance(inputFile, xr.Dataset):\n",
     "            self.ds = inputFile\n",

--- a/pyTEF/tef_core.py
+++ b/pyTEF/tef_core.py
@@ -35,7 +35,7 @@ class constructorTEF:
         if isinstance(inputFile, str):
             try:
                 self._read(inputFile, **kwargs)
-            except (OSError, IOError, RunetimeError):
+            except (OSError, IOError, RuntimeError):
                 raise IOError("Could not read file.")
         elif isinstance(inputFile, xr.Dataset):
             self.ds = inputFile


### PR DESCRIPTION
A simple typo in the word RuntimeError in the function to open a NetCDF dataset is fixed with this commit.