### PR TITLE
Fix typo in word filename when opening NetCDF file

### DIFF
--- a/00_tef_core.ipynb
+++ b/00_tef_core.ipynb
@@ -79,7 +79,7 @@
     "        self.transport = None\n",
     "        self.tracer = None\n",
     "        \n",
-    "    def _read(self, fileName, **kwargs):\n",
+    "    def _read(self, filename, **kwargs):\n",
     "        self.ds = xr.open_dataset(filename, use_cftime=True, **kwargs)\n",
     "        \n",
     "    def _setup(self, data):\n",

--- a/pyTEF/tef_core.py
+++ b/pyTEF/tef_core.py
@@ -49,7 +49,7 @@ class constructorTEF:
         self.transport = None
         self.tracer = None
         
-    def _read(self, fileName, **kwargs):
+    def _read(self, filename, **kwargs):
         self.ds = xr.open_dataset(filename, use_cftime=True, **kwargs)
         
     def _setup(self, data):


### PR DESCRIPTION
The input argument to the private function `_read()` of the TEF constructor was written as `fileName` in the function header, but used as `filename` in the function body, which caused an error.  This commit solves the error by consistently using the notation `filename`.